### PR TITLE
feat(migration): Finish migration for profit check

### DIFF
--- a/contracts/profit-check/examples/schema.rs
+++ b/contracts/profit-check/examples/schema.rs
@@ -5,7 +5,7 @@ use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use profit_check::state::State;
 use white_whale::profit_check::msg::{
-    HandleMsg, InitMsg, LastBalanceResponse, QueryMsg, VaultResponse,
+    ExecuteMsg, InstantiateMsg, LastBalanceResponse, QueryMsg, VaultResponse,
 };
 
 fn main() {
@@ -14,8 +14,8 @@ fn main() {
     create_dir_all(&out_dir).unwrap();
     remove_schemas(&out_dir).unwrap();
 
-    export_schema(&schema_for!(InitMsg), &out_dir);
-    export_schema(&schema_for!(HandleMsg), &out_dir);
+    export_schema(&schema_for!(InstantiateMsg), &out_dir);
+    export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(State), &out_dir);
     export_schema(&schema_for!(LastBalanceResponse), &out_dir);

--- a/packages/white_whale/src/profit_check/msg.rs
+++ b/packages/white_whale/src/profit_check/msg.rs
@@ -3,14 +3,14 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
-pub struct InitMsg {
+pub struct InstantiateMsg {
     pub vault_address: String,
     pub denom: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum HandleMsg {
+pub enum ExecuteMsg {
     BeforeTrade {},
     AfterTrade {},
     SetVault { vault_address: String },


### PR DESCRIPTION
All contracts went through a migration a while back but it appears profit check still has some pre-migration types. This has potential to give some down stream confusing error when we go live so updated. 

Finished profit checkmigration
Updated InitMsg and HandleMsg to InstantiateMsg and ExecuteMsg
Updated tests
Updated schema

resolves #34