### PR TITLE
fix(token_name): Updated token name to whale_token

### DIFF
--- a/contracts/vesting/src/contract.rs
+++ b/contracts/vesting/src/contract.rs
@@ -27,7 +27,7 @@ pub fn instantiate(
         deps.storage,
         &Config {
             owner: deps.api.addr_canonicalize(&msg.owner)?,
-            anchor_token: deps.api.addr_canonicalize(&msg.anchor_token)?,
+            whale_token: deps.api.addr_canonicalize(&msg.whale_token)?,
             genesis_time: msg.genesis_time,
         },
     )?;
@@ -44,9 +44,9 @@ pub fn execute(deps: DepsMut, env: Env, info: MessageInfo, msg: ExecuteMsg) -> S
             match msg {
                 ExecuteMsg::UpdateConfig {
                     owner,
-                    anchor_token,
+                    whale_token,
                     genesis_time,
-                } => update_config(deps, owner, anchor_token, genesis_time),
+                } => update_config(deps, owner, whale_token, genesis_time),
                 ExecuteMsg::RegisterVestingAccounts { vesting_accounts } => {
                     register_vesting_accounts(deps, vesting_accounts)
                 }
@@ -67,7 +67,7 @@ fn assert_owner_privilege(storage: &dyn Storage, api: &dyn Api, sender: Addr) ->
 pub fn update_config(
     deps: DepsMut,
     owner: Option<String>,
-    anchor_token: Option<String>,
+    whale_token: Option<String>,
     genesis_time: Option<u64>,
 ) -> StdResult<Response> {
     let mut config = read_config(deps.storage)?;
@@ -75,8 +75,8 @@ pub fn update_config(
         config.owner = deps.api.addr_canonicalize(&owner)?;
     }
 
-    if let Some(anchor_token) = anchor_token {
-        config.anchor_token = deps.api.addr_canonicalize(&anchor_token)?;
+    if let Some(whale_token) = whale_token {
+        config.whale_token = deps.api.addr_canonicalize(&whale_token)?;
     }
 
     if let Some(genesis_time) = genesis_time {
@@ -135,7 +135,7 @@ pub fn claim(deps: DepsMut, env: Env, info: MessageInfo) -> StdResult<Response> 
         vec![]
     } else {
         vec![CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: deps.api.addr_humanize(&config.anchor_token)?.to_string(),
+            contract_addr: deps.api.addr_humanize(&config.whale_token)?.to_string(),
             funds: vec![],
             msg: to_binary(&Cw20ExecuteMsg::Transfer {
                 recipient: address.to_string(),
@@ -200,7 +200,7 @@ pub fn query_config(deps: Deps) -> StdResult<ConfigResponse> {
     let state = read_config(deps.storage)?;
     let resp = ConfigResponse {
         owner: deps.api.addr_humanize(&state.owner)?.to_string(),
-        anchor_token: deps.api.addr_humanize(&state.anchor_token)?.to_string(),
+        whale_token: deps.api.addr_humanize(&state.whale_token)?.to_string(),
         genesis_time: state.genesis_time,
     };
 

--- a/contracts/vesting/src/msg.rs
+++ b/contracts/vesting/src/msg.rs
@@ -7,7 +7,7 @@ use cosmwasm_std::Uint128;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
     pub owner: String,
-    pub anchor_token: String,
+    pub whale_token: String,
     pub genesis_time: u64,
 }
 
@@ -16,7 +16,7 @@ pub struct InstantiateMsg {
 pub enum ExecuteMsg {
     UpdateConfig {
         owner: Option<String>,
-        anchor_token: Option<String>,
+        whale_token: Option<String>,
         genesis_time: Option<u64>,
     },
     RegisterVestingAccounts {
@@ -56,7 +56,7 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct ConfigResponse {
     pub owner: String,
-    pub anchor_token: String,
+    pub whale_token: String,
     pub genesis_time: u64,
 }
 

--- a/contracts/vesting/src/state.rs
+++ b/contracts/vesting/src/state.rs
@@ -12,7 +12,7 @@ const PREFIX_KEY_VESTING_INFO: &[u8] = b"vesting_info";
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct Config {
     pub owner: CanonicalAddr,
-    pub anchor_token: CanonicalAddr,
+    pub whale_token: CanonicalAddr,
     pub genesis_time: u64,
 }
 

--- a/contracts/vesting/src/tests.rs
+++ b/contracts/vesting/src/tests.rs
@@ -18,7 +18,7 @@ fn proper_initialization() {
 
     let msg = InstantiateMsg {
         owner: "owner".to_string(),
-        anchor_token: "anchor_token".to_string(),
+        whale_token: "whale_token".to_string(),
         genesis_time: 12345u64,
     };
 
@@ -32,7 +32,7 @@ fn proper_initialization() {
         .unwrap(),
         ConfigResponse {
             owner: "owner".to_string(),
-            anchor_token: "anchor_token".to_string(),
+            whale_token: "whale_token".to_string(),
             genesis_time: 12345u64,
         }
     );
@@ -44,7 +44,7 @@ fn update_config() {
 
     let msg = InstantiateMsg {
         owner: "owner".to_string(),
-        anchor_token: "anchor_token".to_string(),
+        whale_token: "whale_token".to_string(),
         genesis_time: 12345u64,
     };
 
@@ -53,7 +53,7 @@ fn update_config() {
 
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("owner2".to_string()),
-        anchor_token: None,
+        whale_token: None,
         genesis_time: None,
     };
     let info = mock_info("owner", &[]);
@@ -66,14 +66,14 @@ fn update_config() {
         .unwrap(),
         ConfigResponse {
             owner: "owner2".to_string(),
-            anchor_token: "anchor_token".to_string(),
+            whale_token: "whale_token".to_string(),
             genesis_time: 12345u64,
         }
     );
 
     let msg = ExecuteMsg::UpdateConfig {
         owner: Some("owner".to_string()),
-        anchor_token: None,
+        whale_token: None,
         genesis_time: None,
     };
     let info = mock_info("owner", &[]);
@@ -85,7 +85,7 @@ fn update_config() {
 
     let msg = ExecuteMsg::UpdateConfig {
         owner: None,
-        anchor_token: Some("anchor_token2".to_string()),
+        whale_token: Some("whale_token2".to_string()),
         genesis_time: Some(1u64),
     };
     let info = mock_info("owner2", &[]);
@@ -98,7 +98,7 @@ fn update_config() {
         .unwrap(),
         ConfigResponse {
             owner: "owner2".to_string(),
-            anchor_token: "anchor_token2".to_string(),
+            whale_token: "whale_token2".to_string(),
             genesis_time: 1u64,
         }
     );
@@ -110,7 +110,7 @@ fn register_vesting_accounts() {
 
     let msg = InstantiateMsg {
         owner: "owner".to_string(),
-        anchor_token: "anchor_token".to_string(),
+        whale_token: "whale_token".to_string(),
         genesis_time: 100u64,
     };
 
@@ -250,7 +250,7 @@ fn claim() {
 
     let msg = InstantiateMsg {
         owner: "owner".to_string(),
-        anchor_token: "anchor_token".to_string(),
+        whale_token: "whale_token".to_string(),
         genesis_time: 100u64,
     };
 
@@ -301,7 +301,7 @@ fn claim() {
     assert_eq!(
         res.messages,
         vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: "anchor_token".to_string(),
+            contract_addr: "whale_token".to_string(),
             msg: to_binary(&Cw20ExecuteMsg::Transfer {
                 recipient: "addr0000".to_string(),
                 amount: Uint128::from(111u128),
@@ -325,7 +325,7 @@ fn claim() {
     assert_eq!(
         res.messages,
         vec![SubMsg::new(CosmosMsg::Wasm(WasmMsg::Execute {
-            contract_addr: "anchor_token".to_string(),
+            contract_addr: "whale_token".to_string(),
             msg: to_binary(&Cw20ExecuteMsg::Transfer {
                 recipient: "addr0000".to_string(),
                 amount: Uint128::from(11u128),


### PR DESCRIPTION
Noticed this when writing up the doc for vesting contract.
Small change, updates the token to whale_token everywhere. Updated tests and verified tests still passing.