### PR TITLE
Rename warchest to treasury for consistency, reformatting code

### DIFF
--- a/contracts/stablecoin-vault/src/tests/callback.rs
+++ b/contracts/stablecoin-vault/src/tests/callback.rs
@@ -46,7 +46,7 @@ fn successful_handle_callback_with_anchor_deposit() {
     mock_instantiate(deps.as_mut());
 
     let msg = ExecuteMsg::Callback {
-        0: CallbackMsg::AfterSuccessfulLoanCallback {}
+        0: CallbackMsg::AfterSuccessfulLoanCallback {},
     };
     let info = mock_info(MOCK_CONTRACT_ADDR, &[]);
 

--- a/contracts/stablecoin-vault/src/tests/flashloan.rs
+++ b/contracts/stablecoin-vault/src/tests/flashloan.rs
@@ -4,14 +4,12 @@ use cw20::{Cw20Coin, Cw20Contract, Cw20ExecuteMsg};
 use terra_multi_test::Executor;
 use terraswap::asset::{Asset, AssetInfo};
 
+use crate::tests::anchor_mock::{contract_anchor_mock, MockInstantiateMsg as AnchorMsg};
+use crate::tests::tswap_mock::{contract_receiver_mock, set_liq_token_addr, MockInstantiateMsg};
 use white_whale::denom::UST_DENOM;
 use white_whale::treasury::msg::InstantiateMsg as TreasuryInitMsg;
 use white_whale::ust_vault::msg::FlashLoanPayload;
 use white_whale::ust_vault::msg::*;
-use crate::tests::anchor_mock::{contract_anchor_mock, MockInstantiateMsg as AnchorMsg};
-use crate::tests::tswap_mock::{
-    contract_receiver_mock, set_liq_token_addr, MockInstantiateMsg,
-};
 
 use crate::contract::{execute, DEFAULT_LP_TOKEN_NAME, DEFAULT_LP_TOKEN_SYMBOL};
 use crate::error::StableVaultError;

--- a/contracts/stablecoin-vault/src/tests/integration_test.rs
+++ b/contracts/stablecoin-vault/src/tests/integration_test.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 use crate::contract::{DEFAULT_LP_TOKEN_NAME, DEFAULT_LP_TOKEN_SYMBOL};
+use crate::tests::anchor_mock::{contract_anchor_mock, MockInstantiateMsg as AnchorMsg};
 use crate::tests::common_integration::{
     contract_cw20_token, contract_profit_check, contract_stablecoin_vault, contract_warchest,
     instantiate_msg, mock_app,
 };
+use crate::tests::tswap_mock::{contract_receiver_mock, set_liq_token_addr, MockInstantiateMsg};
 use cosmwasm_std::{coins, to_binary, Addr, BlockInfo, Timestamp, Uint128};
 use cw20::{Cw20Coin, Cw20Contract, Cw20ExecuteMsg, MinterResponse};
 use terra_multi_test::Executor;
@@ -11,10 +13,6 @@ use terraswap::asset::{Asset, AssetInfo};
 use terraswap::pair::Cw20HookMsg;
 use white_whale::treasury::msg::InstantiateMsg as TreasuryInitMsg;
 use white_whale::ust_vault::msg::ExecuteMsg;
-use crate::tests::anchor_mock::{contract_anchor_mock, MockInstantiateMsg as AnchorMsg};
-use crate::tests::tswap_mock::{
-    contract_receiver_mock, set_liq_token_addr, MockInstantiateMsg,
-};
 
 const DEFAULT_SMALL_AMOUNT_OF_UST: u128 = 10000u128;
 const DEFAULT_LARGE_AMOUNT_OF_UST: u128 = 100000000000000000u128;

--- a/contracts/stablecoin-vault/src/tests/mock_querier.rs
+++ b/contracts/stablecoin-vault/src/tests/mock_querier.rs
@@ -4,19 +4,21 @@
 use cosmwasm_bignumber::{Decimal256, Uint256};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
-    from_binary, from_slice, to_binary, Api, Binary, Coin, ContractResult, Decimal, Empty, OwnedDeps,
-    Querier, QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
+    from_binary, from_slice, to_binary, Api, Binary, Coin, ContractResult, Decimal, Empty,
+    OwnedDeps, Querier, QuerierResult, QueryRequest, SystemError, SystemResult, Uint128, WasmQuery,
 };
 
+use crate::tests::anchor_mock::mock_epoch_state;
 use cosmwasm_storage::to_length_prefixed;
 use cw20::{BalanceResponse as Cw20BalanceResponse, Cw20QueryMsg};
 use std::collections::HashMap;
+use terra_cosmwasm::{
+    SwapResponse, TaxCapResponse, TaxRateResponse, TerraQuery, TerraQueryWrapper, TerraRoute,
+};
 use terraswap::asset::{Asset, AssetInfo, AssetInfoRaw, PairInfo, PairInfoRaw};
 use terraswap::pair::PoolResponse;
 use white_whale::profit_check::msg::LastBalanceResponse;
 use white_whale::query::anchor::EpochStateResponse;
-use crate::tests::anchor_mock::mock_epoch_state;
-use terra_cosmwasm::{TaxCapResponse, TaxRateResponse, TerraQuery, SwapResponse, TerraQueryWrapper, TerraRoute};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.
@@ -69,7 +71,6 @@ pub(crate) fn balances_to_map(
     balances_map
 }
 
-
 #[derive(Clone, Default)]
 pub struct TaxQuerier {
     rate: Decimal,
@@ -93,7 +94,6 @@ pub(crate) fn caps_to_map(caps: &[(&String, &Uint128)]) -> HashMap<String, Uint1
     }
     owner_map
 }
-
 
 #[derive(Clone, Default)]
 pub struct TerraswapPairQuerier {
@@ -157,31 +157,32 @@ impl WasmMockQuerier {
                         }
                         _ => panic!("DO NOT ENTER HERE"),
                     }
-                }
-                else if route == &TerraRoute::Market {
+                } else if route == &TerraRoute::Market {
                     match query_data {
-                        TerraQuery::Swap{offer_coin, ask_denom} => {
-                            let res = SwapResponse{
-                                receive: Coin{
+                        TerraQuery::Swap {
+                            offer_coin,
+                            ask_denom,
+                        } => {
+                            let res = SwapResponse {
+                                receive: Coin {
                                     amount: offer_coin.amount,
-                                    denom: String::from(ask_denom)
-                                }
+                                    denom: String::from(ask_denom),
+                                },
                             };
 
                             SystemResult::Ok(ContractResult::from(to_binary(&res)))
                         }
                         _ => panic!("DO NOT ENTER HERE"),
                     }
-                }
-                else {
+                } else {
                     panic!("DO NOT ENTER HERE")
                 }
             }
             // Manual mocking for smart queries
             // Here we can do alot to mock out messages either by defining a new
-            // MockQueryMsg with each call as a type of it 
+            // MockQueryMsg with each call as a type of it
             // Or for more quick multi-contract mocking consider using the contract_addr
-            // or directly parsing the message if it is unique 
+            // or directly parsing the message if it is unique
             QueryRequest::Wasm(WasmQuery::Smart { contract_addr, msg }) => {
                 // Handle calls for Profit Check; LastBalance
                 if contract_addr == &String::from("test_profit_check") {
@@ -362,7 +363,7 @@ impl WasmMockQuerier {
             base,
             terraswap_pair_querier: TerraswapPairQuerier::default(),
             token_querier: TokenQuerier::default(),
-            tax_querier: TaxQuerier::default()
+            tax_querier: TaxQuerier::default(),
         }
     }
 

--- a/contracts/stablecoin-vault/src/tests/mod.rs
+++ b/contracts/stablecoin-vault/src/tests/mod.rs
@@ -10,10 +10,10 @@ mod integration_test;
 mod mock_querier;
 mod pool;
 
+mod anchor_mock;
 mod deposit;
 mod helpers;
-mod anchor_mock;
-mod tswap_mock;
 mod query;
 mod state;
+mod tswap_mock;
 mod whitelist;

--- a/contracts/stablecoin-vault/src/tests/pool.rs
+++ b/contracts/stablecoin-vault/src/tests/pool.rs
@@ -1,9 +1,9 @@
-use cosmwasm_std::testing::{mock_env};
+use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{to_binary, Api, MessageInfo, Uint128};
 
-use white_whale::ust_vault::msg::ExecuteMsg;
-use white_whale::denom::UST_DENOM;
 use terraswap::asset::{Asset, AssetInfo};
+use white_whale::denom::UST_DENOM;
+use white_whale::ust_vault::msg::ExecuteMsg;
 use white_whale::ust_vault::msg::FlashLoanPayload;
 
 use crate::contract::execute;

--- a/contracts/stablecoin-vault/src/tests/query.rs
+++ b/contracts/stablecoin-vault/src/tests/query.rs
@@ -21,20 +21,17 @@ pub fn test_config_query() {
     let msg = ExecuteMsg::ProvideLiquidity {
         asset: Asset {
             info: AssetInfo::NativeToken {
-                denom: String::from("uusd")
+                denom: String::from("uusd"),
             },
             amount: Uint128::new(1000),
-        }
+        },
     };
     let info = mock_info(TEST_CREATOR, &coins(1000, "uusd"));
     execute(deps.as_mut(), env.clone(), info, msg).unwrap();
 
-
-    let q_res: PoolInfo = from_binary(&query(deps.as_ref(), env, QueryMsg::PoolConfig {}).unwrap()).unwrap();
-    assert_eq!(
-        q_res.stable_cap,
-        Uint128::from(100_000_000u64)
-    )
+    let q_res: PoolInfo =
+        from_binary(&query(deps.as_ref(), env, QueryMsg::PoolConfig {}).unwrap()).unwrap();
+    assert_eq!(q_res.stable_cap, Uint128::from(100_000_000u64))
 }
 
 #[test]

--- a/contracts/stablecoin-vault/src/tests/whitelist.rs
+++ b/contracts/stablecoin-vault/src/tests/whitelist.rs
@@ -3,7 +3,7 @@ use crate::error::StableVaultError;
 use crate::state::STATE;
 use crate::tests::common::{ARB_CONTRACT, TEST_CREATOR};
 use crate::tests::instantiate::mock_instantiate;
-use crate::tests::mock_querier::{mock_dependencies};
+use crate::tests::mock_querier::mock_dependencies;
 use cosmwasm_std::testing::mock_env;
 use cosmwasm_std::{Api, MessageInfo};
 use white_whale::ust_vault::msg::ExecuteMsg;

--- a/contracts/treasury/dapps/anchor/src/lib.rs
+++ b/contracts/treasury/dapps/anchor/src/lib.rs
@@ -1,8 +1,8 @@
 mod commands;
 pub mod contract;
+pub mod dapp_base;
 pub mod error;
 pub mod msg;
-pub mod dapp_base;
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/treasury/dapps/anchor/src/tests/base_mocks/mocks.rs
+++ b/contracts/treasury/dapps/anchor/src/tests/base_mocks/mocks.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::DepsMut;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 

--- a/contracts/treasury/dapps/anchor/src/tests/instantiate.rs
+++ b/contracts/treasury/dapps/anchor/src/tests/instantiate.rs
@@ -1,11 +1,9 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::Api;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::memory::item::Memory;
 use white_whale::treasury::dapp_base::state::{BaseState, BASESTATE};
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 use crate::tests::base_mocks::mocks::instantiate_msg;

--- a/contracts/treasury/dapps/anchor/src/tests/msg.rs
+++ b/contracts/treasury/dapps/anchor/src/tests/msg.rs
@@ -1,10 +1,10 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::Addr;
 
+use crate::dapp_base::common::TEST_CREATOR;
 use white_whale::treasury::dapp_base::error::BaseDAppError;
 use white_whale::treasury::dapp_base::msg::BaseExecuteMsg;
 use white_whale::treasury::dapp_base::state::ADMIN;
-use crate::dapp_base::common::TEST_CREATOR;
 
 use crate::contract::execute;
 use crate::msg::ExecuteMsg;

--- a/contracts/treasury/dapps/astroport/src/lib.rs
+++ b/contracts/treasury/dapps/astroport/src/lib.rs
@@ -1,10 +1,10 @@
 mod commands;
 pub mod contract;
+pub mod dapp_base;
 pub mod error;
 pub mod msg;
 pub mod terraswap_msg;
 pub mod utils;
-pub mod dapp_base; 
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/treasury/dapps/astroport/src/tests/base_mocks/mocks.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/base_mocks/mocks.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::DepsMut;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 

--- a/contracts/treasury/dapps/astroport/src/tests/instantiate.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/instantiate.rs
@@ -7,9 +7,7 @@ use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
 use white_whale::treasury::dapp_base::state::{BaseState, BASESTATE};
 
 use crate::contract::instantiate;
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 
 pub(crate) fn instantiate_msg() -> BaseInstantiateMsg {
     BaseInstantiateMsg {

--- a/contracts/treasury/dapps/astroport/src/tests/integration_tests/common_integration.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/integration_tests/common_integration.rs
@@ -1,3 +1,4 @@
+use crate::dapp_base::common::TEST_CREATOR;
 use astroport::asset::{AssetInfo, PairInfo};
 use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{attr, Addr, Empty, Timestamp, Uint128};
@@ -5,7 +6,6 @@ use terra_mocks::TerraMockQuerier;
 use terra_multi_test::{App, BankKeeper, ContractWrapper, Executor};
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 pub struct BaseContracts {
     pub whale: Addr,

--- a/contracts/treasury/dapps/astroport/src/tests/integration_tests/integration.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/integration_tests/integration.rs
@@ -3,6 +3,7 @@ use cw20::Cw20Contract;
 
 use terra_multi_test::{App, ContractWrapper};
 
+use crate::dapp_base::common::TEST_CREATOR;
 use crate::msg::ExecuteMsg;
 use crate::tests::integration_tests::common_integration::{
     init_contracts, mint_some_whale, mock_app,
@@ -11,7 +12,6 @@ use terra_multi_test::Executor;
 use terraswap::pair::PoolResponse;
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg as InstantiateMsg;
 

--- a/contracts/treasury/dapps/astroport/src/tests/mock_querier.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/mock_querier.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::dapp_base::common::{WHALE_TOKEN, WHALE_UST_LP_TOKEN, WHALE_UST_PAIR};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, OwnedDeps, Querier,
@@ -11,7 +12,6 @@ use terra_cosmwasm::{
 };
 use terraswap::asset::{Asset, PairInfo};
 use terraswap::pair::{PoolResponse, QueryMsg as TerraswapQueryMsg};
-use crate::dapp_base::common::{WHALE_TOKEN, WHALE_UST_LP_TOKEN, WHALE_UST_PAIR};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.

--- a/contracts/treasury/dapps/astroport/src/tests/msg.rs
+++ b/contracts/treasury/dapps/astroport/src/tests/msg.rs
@@ -6,12 +6,12 @@ use white_whale::treasury::dapp_base::msg::BaseExecuteMsg;
 use white_whale::treasury::dapp_base::state::{BaseState, ADMIN, BASESTATE};
 
 use crate::contract::execute;
+use crate::dapp_base::common::MEMORY_CONTRACT;
 use crate::error::AstroportError;
 use crate::msg::ExecuteMsg;
 use crate::tests::base_mocks::mocks::mock_instantiate;
 use crate::tests::common::{TEST_CREATOR, TRADER_CONTRACT};
 use crate::tests::mock_querier::mock_dependencies;
-use crate::dapp_base::common::MEMORY_CONTRACT;
 
 /**
  * BaseExecuteMsg::UpdateConfig

--- a/contracts/treasury/dapps/dapp-template/src/lib.rs
+++ b/contracts/treasury/dapps/dapp-template/src/lib.rs
@@ -1,7 +1,7 @@
 mod commands;
 pub mod contract;
-pub mod msg;
 pub mod dapp_base;
+pub mod msg;
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/treasury/dapps/dapp-template/src/tests/base_mocks/mocks.rs
+++ b/contracts/treasury/dapps/dapp-template/src/tests/base_mocks/mocks.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::DepsMut;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 

--- a/contracts/treasury/dapps/dapp-template/src/tests/instantiate.rs
+++ b/contracts/treasury/dapps/dapp-template/src/tests/instantiate.rs
@@ -1,11 +1,9 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::Api;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::memory::item::Memory;
 use white_whale::treasury::dapp_base::state::{BaseState, BASESTATE};
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 use crate::tests::base_mocks::mocks::instantiate_msg;

--- a/contracts/treasury/dapps/dapp-template/src/tests/integration_tests/common_integration.rs
+++ b/contracts/treasury/dapps/dapp-template/src/tests/integration_tests/common_integration.rs
@@ -1,3 +1,4 @@
+use crate::dapp_base::common::TEST_CREATOR;
 use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{attr, Addr, Empty, Timestamp, Uint128};
 use terra_mocks::TerraMockQuerier;
@@ -5,7 +6,6 @@ use terra_multi_test::{App, BankKeeper, ContractWrapper, Executor};
 use terraswap::asset::{AssetInfo, PairInfo};
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 #[allow(dead_code)]
 pub struct BaseContracts {

--- a/contracts/treasury/dapps/dapp-template/src/tests/msg.rs
+++ b/contracts/treasury/dapps/dapp-template/src/tests/msg.rs
@@ -1,13 +1,11 @@
 use cosmwasm_std::testing::{mock_dependencies, mock_env, mock_info};
 use cosmwasm_std::Addr;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::memory::item::Memory;
 use white_whale::treasury::dapp_base::error::BaseDAppError;
 use white_whale::treasury::dapp_base::msg::BaseExecuteMsg;
 use white_whale::treasury::dapp_base::state::{BaseState, ADMIN, BASESTATE};
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::execute;
 use crate::msg::ExecuteMsg;

--- a/contracts/treasury/dapps/dapp-template/src/tests/query.rs
+++ b/contracts/treasury/dapps/dapp-template/src/tests/query.rs
@@ -1,8 +1,8 @@
 use cosmwasm_std::from_binary;
 use cosmwasm_std::testing::{mock_dependencies, mock_env};
 
-use white_whale::treasury::dapp_base::msg::{BaseQueryMsg, BaseStateResponse};
 use crate::dapp_base::common::{MEMORY_CONTRACT, TRADER_CONTRACT, TREASURY_CONTRACT};
+use white_whale::treasury::dapp_base::msg::{BaseQueryMsg, BaseStateResponse};
 
 use crate::contract::query;
 use crate::msg::QueryMsg;

--- a/contracts/treasury/dapps/terraswap/src/tests/base_mocks/mocks.rs
+++ b/contracts/treasury/dapps/terraswap/src/tests/base_mocks/mocks.rs
@@ -1,10 +1,8 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 use cosmwasm_std::DepsMut;
 
+use crate::dapp_base::common::{MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT};
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
-use crate::dapp_base::common::{
-    MEMORY_CONTRACT, TEST_CREATOR, TRADER_CONTRACT, TREASURY_CONTRACT,
-};
 
 use crate::contract::instantiate;
 

--- a/contracts/treasury/dapps/terraswap/src/tests/integration_tests/common_integration.rs
+++ b/contracts/treasury/dapps/terraswap/src/tests/integration_tests/common_integration.rs
@@ -1,3 +1,4 @@
+use crate::dapp_base::common::TEST_CREATOR;
 use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{attr, Addr, Empty, Timestamp, Uint128};
 use terra_mocks::TerraMockQuerier;
@@ -5,7 +6,6 @@ use terra_multi_test::{App, BankKeeper, ContractWrapper, Executor};
 use terraswap::asset::{AssetInfo, PairInfo};
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 pub struct BaseContracts {
     pub whale: Addr,

--- a/contracts/treasury/dapps/terraswap/src/tests/integration_tests/integration.rs
+++ b/contracts/treasury/dapps/terraswap/src/tests/integration_tests/integration.rs
@@ -3,6 +3,7 @@ use cw20::Cw20Contract;
 
 use terra_multi_test::{App, ContractWrapper};
 
+use crate::dapp_base::common::TEST_CREATOR;
 use crate::msg::ExecuteMsg;
 use crate::tests::integration_tests::common_integration::{
     init_contracts, mint_some_whale, mock_app,
@@ -11,7 +12,6 @@ use terra_multi_test::Executor;
 use terraswap::pair::PoolResponse;
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg as InstantiateMsg;
 

--- a/contracts/treasury/dapps/terraswap/src/tests/mock_querier.rs
+++ b/contracts/treasury/dapps/terraswap/src/tests/mock_querier.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+use crate::dapp_base::common::{WHALE_TOKEN, WHALE_UST_LP_TOKEN, WHALE_UST_PAIR};
 use cosmwasm_std::testing::{MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{
     from_binary, from_slice, to_binary, Coin, ContractResult, Decimal, OwnedDeps, Querier,
@@ -11,7 +12,6 @@ use terra_cosmwasm::{
 };
 use terraswap::asset::{Asset, PairInfo};
 use terraswap::pair::{PoolResponse, QueryMsg as TerraswapQueryMsg};
-use crate::dapp_base::common::{WHALE_TOKEN, WHALE_UST_LP_TOKEN, WHALE_UST_PAIR};
 
 /// mock_dependencies is a drop-in replacement for cosmwasm_std::testing::mock_dependencies
 /// this uses our CustomQuerier.

--- a/contracts/treasury/dapps/terraswap/src/tests/msg.rs
+++ b/contracts/treasury/dapps/terraswap/src/tests/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::testing::{mock_env, mock_info};
 
-use white_whale::treasury::dapp_base::error::BaseDAppError;
 use crate::dapp_base::common::TRADER_CONTRACT;
+use white_whale::treasury::dapp_base::error::BaseDAppError;
 
 use crate::contract::execute;
 use crate::error::TerraswapError;

--- a/contracts/treasury/dapps/vault-dapp/src/lib.rs
+++ b/contracts/treasury/dapps/vault-dapp/src/lib.rs
@@ -1,11 +1,11 @@
 mod commands;
 pub mod contract;
+pub mod dapp_base;
 pub mod error;
 pub mod msg;
 pub mod queries;
 pub mod response;
 pub mod state;
-pub mod dapp_base;
 
 #[cfg(test)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/contracts/treasury/dapps/vault-dapp/src/tests/base_mocks/mocks.rs
+++ b/contracts/treasury/dapps/vault-dapp/src/tests/base_mocks/mocks.rs
@@ -1,5 +1,5 @@
-use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
 use crate::dapp_base::common::{MEMORY_CONTRACT, TRADER_CONTRACT, TREASURY_CONTRACT};
+use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
 
 #[allow(dead_code)]
 pub(crate) fn instantiate_msg() -> BaseInstantiateMsg {

--- a/contracts/treasury/dapps/vault-dapp/src/tests/integration_tests/common_integration.rs
+++ b/contracts/treasury/dapps/vault-dapp/src/tests/integration_tests/common_integration.rs
@@ -1,3 +1,4 @@
+use crate::dapp_base::common::TEST_CREATOR;
 use cosmwasm_std::testing::{mock_env, MockApi, MockQuerier, MockStorage, MOCK_CONTRACT_ADDR};
 use cosmwasm_std::{attr, Addr, Empty, Timestamp, Uint128};
 use terra_mocks::TerraMockQuerier;
@@ -5,7 +6,6 @@ use terra_multi_test::{App, BankKeeper, ContractWrapper, Executor};
 use terraswap::asset::{AssetInfo, PairInfo};
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
-use crate::dapp_base::common::TEST_CREATOR;
 
 pub struct BaseContracts {
     pub whale: Addr,

--- a/contracts/treasury/dapps/vault-dapp/src/tests/integration_tests/integration.rs
+++ b/contracts/treasury/dapps/vault-dapp/src/tests/integration_tests/integration.rs
@@ -10,10 +10,10 @@ use crate::tests::integration_tests::common_integration::{
 use terra_multi_test::Executor;
 use terraswap::asset::Asset;
 
+use crate::dapp_base::common::TEST_CREATOR;
 use white_whale::memory::msg as MemoryMsg;
 use white_whale::treasury::msg as TreasuryMsg;
 use white_whale::treasury::vault_assets::{ValueRef, VaultAsset};
-use crate::dapp_base::common::TEST_CREATOR;
 
 use white_whale::treasury::dapp_base::msg::BaseInstantiateMsg;
 

--- a/packages/white_whale/src/ust_vault/msg.rs
+++ b/packages/white_whale/src/ust_vault/msg.rs
@@ -1,12 +1,14 @@
-use crate::fee::{Fee, VaultFee};
+use std::fmt;
+
 use cosmwasm_std::{
     to_binary, Addr, Binary, Coin, CosmosMsg, Decimal, StdResult, Uint128, WasmMsg,
 };
 use cw20::Cw20ReceiveMsg;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt;
 use terraswap::asset::{Asset, AssetInfo};
+
+use crate::fee::{Fee, VaultFee};
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct InstantiateMsg {
@@ -30,13 +32,9 @@ pub enum ExecuteMsg {
     /// Receive hook for the liquidity token
     Receive(Cw20ReceiveMsg),
     /// Provide liquidity to the vault
-    ProvideLiquidity {
-        asset: Asset,
-    },
+    ProvideLiquidity { asset: Asset },
     /// Set minimum amount of stables held liquid (not deposited into anchor)
-    SetStableCap {
-        stable_cap: Uint128,
-    },
+    SetStableCap { stable_cap: Uint128 },
     /// Sets the withdraw fee and flash loan fee
     SetFee {
         flash_loan_fee: Option<Fee>,
@@ -44,21 +42,13 @@ pub enum ExecuteMsg {
         commission_fee: Option<Fee>,
     },
     /// Forwards the profit amount to the vault, is called by profit-check
-    SendWarchestCommission { 
-        profit: Uint128 
-    },
+    SendTreasuryCommission { profit: Uint128 },
     /// Set the admin of the contract
-    SetAdmin {
-        admin: String,
-    },
+    SetAdmin { admin: String },
     /// Add provided contract to the whitelisted contracts
-    AddToWhitelist {
-        contract_addr: String,
-    },
+    AddToWhitelist { contract_addr: String },
     /// Remove provided contract from the whitelisted contracts
-    RemoveFromWhitelist {
-        contract_addr: String,
-    },
+    RemoveFromWhitelist { contract_addr: String },
     /// Update the interal State struct
     UpdateState {
         anchor_money_market_address: Option<String>,
@@ -67,9 +57,7 @@ pub enum ExecuteMsg {
         allow_non_whitelisted: Option<bool>,
     },
     /// Execute a flashloan
-    FlashLoan {
-        payload: FlashLoanPayload,
-    },
+    FlashLoan { payload: FlashLoanPayload },
     /// Internal callback message
     Callback(CallbackMsg),
 }


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
:white_small_square: Enhancement
:white_small_square: Refactoring
:black_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
Changed `SendWarchestCommission` to `SendTreasuryCommission` to keep names consistent.

Also needed to reformat bunch of files again.

## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->
N/A

## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:black_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
