### PR TITLE
Fix hook's unary operator expected error

### DIFF
--- a/scripts/git_hooks/pre-commit.sh
+++ b/scripts/git_hooks/pre-commit.sh
@@ -68,7 +68,7 @@ format_check() {
       else
         not_staged_file=$(git diff --name-only -- $file)
 
-        if [ $not_staged_file != "" ]; then # it means the file changed and it's not staged, i.e. rustfmt did the job.
+        if [ "$not_staged_file" != "" ]; then # it means the file changed and it's not staged, i.e. rustfmt did the job.
           git add $not_staged_file
         fi
       fi


### PR DESCRIPTION
## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:black_small_square: Bugfix
:white_small_square: New feature
:white_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->
In line 71, if `not_staged_file` was empty then bash tries to interpret the expression `!= ""` instead of `"" != ""`. Surrounding the variable with quotes fixes this.

P.S.: DO NOT FORGET TO REINSTALL THE HOOK AFTER THIS IS MERGED.

## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->
N/A

## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:black_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
