### PR TITLE
fix(exchange-rate): Provide the current block to avoid cached Anchor…

### DIFF
--- a/contracts/treasury/dapps/anchor/src/commands.rs
+++ b/contracts/treasury/dapps/anchor/src/commands.rs
@@ -54,7 +54,7 @@ pub fn handle_deposit_stable(
 /// Caller address -> anchor-dapp -> Treasury executes message prepared by the anchor-dapp invoked by the caller address which is an admin
 pub fn handle_redeem_stable(
     deps: Deps,
-    _env: Env,
+    env: Env,
     info: MessageInfo,
     ust_to_withdraw: Uint128,
 ) -> AnchorResult {
@@ -78,7 +78,7 @@ pub fn handle_redeem_stable(
 
     let mut messages: Vec<CosmosMsg> = vec![];
 
-    let aust_exchange_rate = query_aust_exchange_rate(deps, anchor_address.to_string())?;
+    let aust_exchange_rate = query_aust_exchange_rate(env, deps, anchor_address.to_string())?;
 
     // Prepare a deposit_msg using the provided info.
     // The anchor dapp will then use this message and pass it to the treasury for execution

--- a/packages/white_whale/src/query/anchor.rs
+++ b/packages/white_whale/src/query/anchor.rs
@@ -1,5 +1,5 @@
 use cosmwasm_bignumber::{Decimal256, Uint256};
-use cosmwasm_std::{to_binary, Decimal, Deps, QueryRequest, StdResult, WasmQuery};
+use cosmwasm_std::{to_binary, Decimal, Deps, Env, QueryRequest, StdResult, WasmQuery};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -19,6 +19,7 @@ pub struct EpochStateResponse {
 }
 
 pub fn query_aust_exchange_rate(
+    env: Env,
     deps: Deps,
     anchor_money_market_address: String,
 ) -> StdResult<Decimal> {
@@ -26,7 +27,7 @@ pub fn query_aust_exchange_rate(
         deps.querier.query(&QueryRequest::Wasm(WasmQuery::Smart {
             contract_addr: anchor_money_market_address,
             msg: to_binary(&AnchorQuery::EpochState {
-                block_height: None,
+                block_height: Some(env.block.height),
                 distributed_interest: None,
             })?,
         }))?;


### PR DESCRIPTION
… queries


Now when querying the anchor EpochState we provide the current block height rather than none. This ensures queries are up to date to the block we are attempting to query from.

+ Updated query_aust_exchange_rate to accept an Env param in order to access blockheight.
+ Refactored `compute_total_value` which used that query.

Fixes #130

## :loudspeaker: Type of change
<!--- add a :black_small_square: in the boxes that apply -->
:white_small_square: Bugfix
:white_small_square: New feature
:white_small_square: Enhancement
:white_small_square: Refactoring
:white_small_square: Maintenance

## :scroll: Description and Motivation
<!--- Describe your changes in detail. Why is this change required? What problem does it solve? -->


## :hammer_and_wrench: How to test (if applicable)
<!--- Describe the steps the reviewer needs to take to verify the changes -->


## :pencil: Checklist
<!--- add a :black_small_square: in the boxes that apply -->

:white_small_square: Reviewed submitted code
:white_small_square: Added tests to verify changes
:white_small_square: Updated docs
:white_small_square: Verified on testnet
